### PR TITLE
Fix MSVC build issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,13 +28,13 @@ jobs:
 
       - name: Build
         run: |
-          meson setup build
-          cd build
-          meson compile
+          meson setup build -Dbuildtype=release
+          meson compile -C build
 
       - name: Test Cython version
         run: |
-          PYTHONPATH=".\build\cython" python -c "import npycomplex; npycomplex.main()"
+          cd build/cython
+          python -c "import npycomplex; npycomplex.main()"
 
   build-unix:
     strategy:

--- a/cython/meson.build
+++ b/cython/meson.build
@@ -2,4 +2,4 @@ src = ['npycomplex.pyx', '../lib/print.c']
 py3.extension_module('npycomplex',
            src,
            include_directories: [inc_np, inc_lib],
-           dependencies : py3_dep)
+)

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,6 @@
 project('npycomplex', 'c', 'cython')
 
-py_mod = import('python')
-py3 = py_mod.find_installation()
+py3 = import('python').find_installation(pure: false)
 py3_dep = py3.dependency()
 
 incdir_numpy = run_command(py3,
@@ -12,8 +11,5 @@ inc_np = include_directories(incdir_numpy)
 
 inc_lib = include_directories('.')
 
-if target_machine.system() != 'windows'
-  subdir('c')
-endif
-
+subdir('c')
 subdir('cython')


### PR DESCRIPTION
- Use "release" build type to avoid link error
- Avoid use of PYTHONPATH, the Windows terminal thinks that's a command
- Re-enable C build on Windows
- Some minor cleanups in meson.build files